### PR TITLE
Add custom endpoint option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ adding an option in your apt configuration, e.g.
 echo "Acquire::s3::region us-east-1;" > /etc/apt/apt.conf.d/s3
 ```
 
+You may also override the endpoint used for S3 requests. This is useful when
+connecting to S3-compatible services.
+
+```plain
+echo "Acquire::s3::endpoint https://minio.example.com;" > /etc/apt/apt.conf.d/s3
+```
+
 Alternatively, you may specify an IAM role to assume before connecting to S3.
 The role will be assumed using the default credential chain; this option is
 mutually exclusive with static credentials in the S3 URL.

--- a/method/method_test.go
+++ b/method/method_test.go
@@ -53,6 +53,12 @@ Config-Item: Aptitude::Get-Root-Command=sudo:/usr/bin/sudo
 Config-Item: Unattended-Upgrade::Allowed-Origins::=${distro_id}:${distro_codename}-security
 
 `
+
+	// The trailing blank line is intentional.
+	endpointConfigMsg = `601 Configuration
+Config-Item: Acquire::s3::endpoint=https://minio.example.com
+
+`
 )
 
 func TestCapabilities(t *testing.T) {
@@ -102,6 +108,25 @@ func TestSettingRegion(t *testing.T) {
 	expected := "us-east-2"
 	if method.region != expected {
 		t.Errorf("method.region = %s; expected %s", method.region, expected)
+	}
+}
+
+func TestSettingEndpoint(t *testing.T) {
+	reader := strings.NewReader(endpointConfigMsg)
+	method := New(logger(t))
+	go method.readInput(reader)
+
+	for {
+		bytes := <-method.msgChan
+		method.handleBytes(bytes)
+		if reader.Len() == 0 {
+			break
+		}
+	}
+
+	expected := "https://minio.example.com"
+	if method.endpoint != expected {
+		t.Errorf("method.endpoint = %s; expected %s", method.endpoint, expected)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow specifying a custom S3 endpoint via `Acquire::s3::endpoint`
- honor the endpoint when creating the S3 client
- test configuration of the endpoint
- document the new option
- fix indentation in the test configuration fixture

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686c0b11f6cc8324a90078e2c7b0cdda